### PR TITLE
fix: Coupon entity의 coupon_status 중복 매핑 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/simsimbookstore/apiserver/entity/Coupon.java
+++ b/src/main/java/com/simsimbookstore/apiserver/entity/Coupon.java
@@ -25,8 +25,8 @@ public class Coupon {
     @Column(name = "coupon_status")
     private CouponStatus couponStatus;
 
-    @Column(name = "coupon_status")
-    private LocalDateTime userDate;
+    @Column(name = "use_date")
+    private LocalDateTime useDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coupon_type_id")
@@ -40,14 +40,14 @@ public class Coupon {
         USED, EXPIRED, UNUSED
     }
     @Builder
-    public Coupon(Long couponId, LocalDateTime issueDate, LocalDateTime deadline, CouponStatus couponStatus, LocalDateTime userDate, CouponType couponType
+    public Coupon(Long couponId, LocalDateTime issueDate, LocalDateTime deadline, CouponStatus couponStatus, LocalDateTime useDate, CouponType couponType
 //            , User user
             ) {
         this.couponId = couponId;
         this.issueDate = issueDate;
         this.deadline = deadline;
         this.couponStatus = couponStatus;
-        this.userDate = userDate;
+        this.useDate = useDate;
         this.couponType = couponType;
 //        this.user = user;
     }


### PR DESCRIPTION
Coupon 엔티티에서 coupon_status 컬럼이 중복 매핑되는 버그를 수정하였습니다.