### PR TITLE
feat:관리자가 도서 관리하는 로직 구현 및 테스트 구현,도서이미지 엔티티 수정

### DIFF
--- a/src/main/java/com/simsimbookstore/apiserver/books/book/aladin/AladinApiService.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/aladin/AladinApiService.java
@@ -104,7 +104,7 @@ public class AladinApiService {
         BookImagePath bookImagePath = BookImagePath.builder()
                 .book(book)
                 .imagePath(imagePath)
-                .thumbnail(false)
+                .imageType(BookImagePath.ImageType.THUMBNAIL)
                 .build();
 
         bookImageRepoisotry.save(bookImagePath);

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/aladin/BookAladinController.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/aladin/BookAladinController.java
@@ -1,6 +1,5 @@
-package com.simsimbookstore.apiserver.books.book.controller;
+package com.simsimbookstore.apiserver.books.book.aladin;
 
-import com.simsimbookstore.apiserver.books.book.aladin.AladinApiService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/controller/BookGetController.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/controller/BookGetController.java
@@ -1,0 +1,34 @@
+package com.simsimbookstore.apiserver.books.book.controller;
+
+
+import com.simsimbookstore.apiserver.books.book.dto.BookListResponse;
+import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
+import com.simsimbookstore.apiserver.books.book.service.BookGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/shop/books")
+public class BookGetController {
+
+    private final BookGetService bookGetService;
+
+    @GetMapping
+    public ResponseEntity<Page<BookListResponse>> getAllBooks(@RequestParam(defaultValue = "0") int page,
+                                                              @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<BookListResponse> books = bookGetService.getAllBook(pageable);
+        return ResponseEntity.ok(books);
+    }
+
+
+}

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/controller/BookManagementController.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/controller/BookManagementController.java
@@ -1,0 +1,80 @@
+package com.simsimbookstore.apiserver.books.book.controller;
+
+import com.simsimbookstore.apiserver.books.book.dto.BookGiftResponse;
+import com.simsimbookstore.apiserver.books.book.dto.BookRequestDto;
+import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
+import com.simsimbookstore.apiserver.books.book.dto.BookStatusResponseDto;
+import com.simsimbookstore.apiserver.books.book.service.BookManagementService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.json.HTTP;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/shop/books")
+@RequiredArgsConstructor
+public class BookManagementController {
+
+    private final BookManagementService bookManagementService;
+
+    /**
+     * 도서 등록
+     *
+     * @param requestDto
+     * @return
+     */
+    @PostMapping
+    public ResponseEntity<?> createBook(@RequestBody @Valid BookRequestDto requestDto) {
+        BookResponseDto bookResponseDto = bookManagementService.registerBook(requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(bookResponseDto);
+
+    }
+
+    /**
+     * 도서 수정인데 도서 상태는 수정 안되게 되어있음
+     *
+     * @param bookId
+     * @param requestDto
+     * @return
+     */
+    @PatchMapping("/{bookId}")
+    private ResponseEntity<?> updateBook(@PathVariable(name = "bookId") Long bookId, @RequestBody @Valid BookRequestDto requestDto) {
+        BookResponseDto bookResponseDto = bookManagementService.updateBook(bookId, requestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(bookResponseDto);
+    }
+
+    /**
+     * 도서 상태 수정 도서 상태만 수정가능 다른 컬럼들은 수정 x
+     * @param bookId
+     * @param bookRequestDto
+     * @return
+     */
+    @PatchMapping("/status/{bookId}")
+    public ResponseEntity<BookStatusResponseDto> modifyBookStatus(@PathVariable(name = "bookId") Long bookId, @RequestBody @Valid BookRequestDto bookRequestDto) {
+        BookStatusResponseDto bookStatusResponseDto = bookManagementService.modifyBookStatus(bookId, bookRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(bookStatusResponseDto);
+    }
+
+    /**
+     * 수량 추가,감소 로직
+     * @param bookId
+     * @param quantity
+     * @return
+     */
+    @PatchMapping("/quantity/{bookId}")
+    public ResponseEntity<Integer> modifyBookQuantity(@PathVariable(name = "bookId") Long bookId,@RequestParam(name = "quantity") int quantity){
+        int updateQuantity = bookManagementService.modifyQuantity(bookId, quantity);
+        return ResponseEntity.status(HttpStatus.OK).body(updateQuantity);
+    }
+
+    @PatchMapping("/gift/{bookId}")
+    public ResponseEntity<BookGiftResponse> modifyGift(@PathVariable(name = "bookId") Long bookId,@RequestBody @Valid BookRequestDto bookRequestDto){
+        BookGiftResponse bookGiftResponse = bookManagementService.modifyBookGift(bookId, bookRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(bookGiftResponse);
+
+    }
+
+}

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/dto/BookGiftResponse.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/dto/BookGiftResponse.java
@@ -1,0 +1,16 @@
+package com.simsimbookstore.apiserver.books.book.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BookGiftResponse {
+
+    private boolean giftPackaging;
+}

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/dto/BookListResponse.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/dto/BookListResponse.java
@@ -32,7 +32,7 @@ public class BookListResponse {
 
     private BookStatus bookStatus;
 
-    private int quntity;
+    private int quantity;
 
     private Long bookLikeId;
 

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/dto/BookRequestDto.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/dto/BookRequestDto.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -54,13 +55,16 @@ public class BookRequestDto {
     private BigDecimal saleprice;
 
     @NotNull(message = "출판일은 필수 입력 항목입니다")
-    private LocalDateTime publicationDate;
+    private LocalDate publicationDate;
 
     @Min(value = 1, message = "페이지 수는 1 이상이어야 합니다")
     private int pages;
 
     @NotNull(message = "책 상태는 필수 입력 항목입니다")
     private BookStatus bookStatus;
+
+    @NotNull
+    private boolean giftPackaging; //true면 포장 가능
 
 
     private List<Long> contributoridList;

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/mapper/BookMapper.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/mapper/BookMapper.java
@@ -1,11 +1,14 @@
 package com.simsimbookstore.apiserver.books.book.mapper;
 
 import com.simsimbookstore.apiserver.books.book.dto.BookRequestDto;
-//import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
+
 import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
 import com.simsimbookstore.apiserver.books.book.entity.Book;
 
+
 import java.time.LocalDate;
+import java.util.Optional;
+
 
 public class BookMapper {
 
@@ -13,8 +16,18 @@ public class BookMapper {
     public static BookResponseDto toResponseDto(Book book) {
         return BookResponseDto.builder()
                 .bookId(book.getBookId())
+                .title(book.getTitle())
+                .description(book.getDescription())
+                .bookIndex(book.getBookIndex())
+                .publisher(book.getPublisher())
                 .isbn(book.getIsbn())
                 .viewCount(book.getViewCount())
+                .price(book.getPrice())
+                .saleprice(book.getSaleprice())
+                .publicationDate(book.getPublicationDate())
+                .pages(book.getPages())
+                .quantity(book.getQuantity())
+                .bookStatus(book.getBookStatus())
                 .build();
     }
 
@@ -23,15 +36,18 @@ public class BookMapper {
                 .title(bookRequestDto.getTitle())
                 .description(bookRequestDto.getDescription())
                 .bookIndex(bookRequestDto.getBookIndex())
-                .publisher(bookRequestDto.getPublisher())
+                .publisher(bookRequestDto.getPublisher()) //출판사
                 .isbn(bookRequestDto.getIsbn())
                 .quantity(bookRequestDto.getQuantity())
                 .price(bookRequestDto.getPrice())
                 .saleprice(bookRequestDto.getSaleprice())
-                .publicationDate(LocalDate.from(bookRequestDto.getPublicationDate()))
-                .giftPackaging(true)
+               .publicationDate(Optional.ofNullable(bookRequestDto.getPublicationDate())
+                                     .map(LocalDate::from)
+                                     .orElse(LocalDate.now())) // null인 경우 현재 날짜
+                .giftPackaging(bookRequestDto.isGiftPackaging())
                 .pages(bookRequestDto.getPages())
                 .bookStatus(bookRequestDto.getBookStatus())
+                .viewCount(0L)
                 .build();
     }
 }

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/repository/BookCustomRepositoryImpl.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/repository/BookCustomRepositoryImpl.java
@@ -2,24 +2,34 @@ package com.simsimbookstore.apiserver.books.book.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.simsimbookstore.apiserver.books.book.dto.BookListResponse;
 import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
 import com.simsimbookstore.apiserver.books.book.entity.QBook;
 import com.simsimbookstore.apiserver.books.bookcategory.entity.QBookCategory;
+import com.simsimbookstore.apiserver.books.bookcontributor.dto.BookContributorResponsDto;
 import com.simsimbookstore.apiserver.books.bookcontributor.entity.QBookContributor;
 import com.simsimbookstore.apiserver.books.booktag.entity.QBookTag;
+import com.simsimbookstore.apiserver.books.category.dto.CategoryResponseDto;
+import com.simsimbookstore.apiserver.books.category.entity.Category;
 import com.simsimbookstore.apiserver.books.category.entity.QCategory;
 import com.simsimbookstore.apiserver.books.contributor.entity.QContributor;
 import com.simsimbookstore.apiserver.books.tag.domain.QTag;
+import com.simsimbookstore.apiserver.books.tag.dto.TagResponseDto;
 import com.simsimbookstore.apiserver.like.entity.QBookLike;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 
 public class BookCustomRepositoryImpl implements BookCustomRepository {
 
@@ -31,7 +41,7 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
     QBookCategory bookCategory = QBookCategory.bookCategory;
     QContributor contributor = QContributor.contributor;
     QTag tag = QTag.tag;
-    QBookTag qBookTag = QBookTag.bookTag;
+    QBookTag bookTag = QBookTag.bookTag;
     QBookLike bookLike = QBookLike.bookLike;
 
     public BookCustomRepositoryImpl(JPAQueryFactory queryFactory) {
@@ -87,7 +97,7 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
                 .from(book)
                 .offset(pageable.getOffset()) // 페이지 시작점
                 .limit(pageable.getPageSize()) // 페이지 크기
-                .orderBy(book.publicationDate.desc()) // 출판일 기준 최신순 정렬
+                .orderBy(book.publicationDate.asc()) // 출판일 기준 최신순 정렬
                 .fetch();
 
         // 전체 데이터 수 조회 (페이징 처리에 필요)
@@ -144,19 +154,84 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
         // 조회수 증가
         this.addViewCount(book, bookId);
 
-        return bookResponse;
+        return this.toResponse(bookId, bookResponse);
 
     }
 
     /**
      * 도서 상세정보에 대한 객체를 반환하는 메서드
+     *
      * @param bookId
      * @param bookResponseDto
      * @return
      */
-    private BookResponseDto toResponse(Long bookId, BookResponseDto bookResponseDto){
-        return null;
+    private BookResponseDto toResponse(Long bookId, BookResponseDto bookResponseDto) {
+        // 기여자 역할 정보 설정
+        List<BookContributorResponsDto> bookContributorResponsDtoList = queryFactory
+                .select(Projections.fields(
+                        BookContributorResponsDto.class,
+                        bookContributor.contributor.contributorId,
+                        bookContributor.contributor.contributorName
+                ))
+                .from(bookContributor)
+                .innerJoin(contributor).on(bookContributor.contributor.contributorId.eq(contributor.contributorId))
+                .where(bookContributor.book.bookId.eq(bookId))
+                .fetch();
 
+        // 책에 연관된 카테고리 ID를 가져옵니다.
+        List<Long> categoryIdList = queryFactory
+                .select(bookCategory.catagory.categoryId) // 카테고리 ID를 선택
+                .from(bookCategory)                       // bookCategory 테이블 기준
+                .join(bookCategory.catagory, category)    // bookCategory와 category를 조인
+                .where(bookCategory.book.bookId.eq(bookId)) // 특정 책 ID에 해당하는 카테고리 필터
+                .fetch();                                 // 결과 가져오기
+
+        // 필요한 카테고리와 부모 정보를 미리 로드합니다.
+        Map<Long, Category> categoryMap = queryFactory
+                .selectFrom(category)
+                .where(category.categoryId.in(categoryIdList))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(Category::getCategoryId, Function.identity()));
+
+        List<List<CategoryResponseDto>> categoriesList = new ArrayList<>();
+
+        // 각 카테고리에 대해 계층 구조를 생성합니다.
+        for (Long categoryId : categoryIdList) {
+            List<CategoryResponseDto> categories = new ArrayList<>();
+            Category currentCategory = categoryMap.get(categoryId);
+
+            while (currentCategory != null) {
+                CategoryResponseDto dto = CategoryResponseDto.builder()
+                        .categoryId(currentCategory.getCategoryId())
+                        .categoryName(currentCategory.getCategoryName())
+                        .parentId(currentCategory.getParent() != null ? currentCategory.getParent().getCategoryId() : null)
+                        .parentName(currentCategory.getParent() != null ? currentCategory.getParent().getCategoryName() : null)
+                        .build();
+                categories.add(dto);
+                currentCategory = currentCategory.getParent();
+            }
+
+            // 계층 순서를 뒤집어서 올바른 순서로 저장
+            Collections.reverse(categories);
+            categoriesList.add(categories);
+        }
+
+        List<TagResponseDto> bookTagList = queryFactory
+                .select(Projections.fields(TagResponseDto.class,
+                        tag.tagId,
+                        tag.tagName))
+                .from(bookTag)
+                .innerJoin(tag).on(bookTag.tag.tagId.eq(tag.tagId))
+                .where(bookTag.book.bookId.eq(bookId))
+                .fetch();
+
+        bookResponseDto.setContributorRoleList(bookContributorResponsDtoList);
+        bookResponseDto.setCategoryList(categoriesList);
+        bookResponseDto.setTagList(bookTagList);
+
+
+        return bookResponseDto;
     }
 
     /**
@@ -167,7 +242,6 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
      */
     @Override
     public List<Long> getLowestCategoryId(List<Long> categoryIdList) {
-        // 입력이 없는 경우 빈 리스트 반환
         if (categoryIdList == null || categoryIdList.isEmpty()) {
             return List.of();
         }
@@ -175,32 +249,73 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
         return queryFactory
                 .select(category.categoryId)
                 .from(category)
-                .leftJoin(category.children, QCategory.category) // 자식 카테고리 조인
-                .where(isInCategoryList(categoryIdList)         // 카테고리 ID 리스트 내에 있는지
-                        .and(hasNoChildren()))                   // 자식 카테고리가 없는지 확인
+                .where(category.categoryId.in(categoryIdList)
+                        .and(category.children.isEmpty())) // 자식 카테고리가 없는 조건
                 .fetch();
     }
 
 
     /**
      * 회원이 좋아요한 책을 조회하는 메서드
+     *
      * @param pageable
      * @param userId
      * @return
      */
     @Override
     public Page<BookListResponse> getUserLikeBook(Pageable pageable, Long userId) {
-        return null;
+
+        BooleanExpression isLiked = this.getLikeExpression(userId);
+
+        // 좋아요한 책 데이터 조회
+        List<BookListResponse> bookList = queryFactory
+                .select(Projections.fields(BookListResponse.class,
+                        book.bookId.as("bookId"),           // 책 ID
+                        book.title.as("title"),             // 책 제목
+                        book.bookStatus.as("bookStatus"),   // 책 상태
+                        book.quantity.as("quantity"),       // 책 재고
+                        isLiked.as("isLiked")
+                ))
+                .from(bookLike)
+                .join(bookLike.book, book) // bookLike와 book 조인
+                .where(bookLike.user.userId.eq(userId)) // 특정 회원이 좋아요한 책만 필터링
+                .offset(pageable.getOffset())          // 페이징 시작점
+                .limit(pageable.getPageSize())         // 페이지 크기
+                .fetch();
+
+        // 전체 좋아요 데이터 수 조회
+        Long totalCount = queryFactory
+                .select(bookLike.count())
+                .from(bookLike)
+                .where(bookLike.user.userId.eq(userId)) // 특정 회원이 좋아요한 책만 카운트
+                .fetchOne();
+
+        // Page 객체로 반환
+        return PageableExecutionUtils.getPage(bookList, pageable, () -> totalCount);
     }
 
 
+    /**
+     * 책 수량을 조회하는 메서드
+     *
+     * @param bookIdList
+     * @return
+     */
     @Override
     public List<BookListResponse> getBooksForCheck(List<Long> bookIdList) {
-        return List.of();
+        return queryFactory.select(Projections.fields(BookListResponse.class
+                        , book.bookId
+                        , book.title
+                        , book.saleprice
+                        , book.quantity))
+                .from(book)
+                .where(book.bookId.in(bookIdList))
+                .fetch();
     }
 
     /**
      * 주문량이 많은 책 조회
+     *
      * @return
      */
     @Override
@@ -221,23 +336,12 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
                 .execute();
     }
 
-    // 카테고리 ID 리스트 필터
-    private BooleanExpression isInCategoryList(List<Long> categoryIdList) {
-        return category.categoryId.in(categoryIdList);
-    }
-
-    // 자식 카테고리가 없는 조건
-    private BooleanExpression hasNoChildren() {
-        return category.children.isEmpty();
-    }
 
     private BooleanExpression getLikeExpression(Long userId) {
-        if (userId == null) {
-            // 로그인하지 않은 사용자
-            return Expressions.asBoolean(false);
-        }
-        // 로그인한 사용자의 좋아요 여부 확인
-        return bookLike.user.userId.eq(userId);
+        return userId == null
+                ? Expressions.asBoolean(false) // 로그인하지 않은 사용자
+                : bookLike.user.userId.eq(userId); // 로그인한 사용자의 좋아요 여부 확인
     }
+
 
 }

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/service/BookGetService.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/service/BookGetService.java
@@ -1,0 +1,37 @@
+package com.simsimbookstore.apiserver.books.book.service;
+
+import com.simsimbookstore.apiserver.books.book.dto.BookListResponse;
+import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
+import com.simsimbookstore.apiserver.books.book.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookGetService {
+
+    private final BookRepository bookRepository;
+
+    public Page<BookListResponse> getAllBook(Pageable pageable) {
+        // QueryDSL로 데이터 조회
+        Page<BookListResponse> responses = bookRepository.getAllBook(pageable)
+                .map(book -> BookListResponse.builder()
+                        .bookId(book.getBookId())
+                        .title(book.getTitle())
+                        .publicationDate(book.getPublicationDate())
+                        .price(book.getPrice())
+                        .saleprice(book.getSaleprice())
+                        .publisher(book.getPublisher())
+                        .bookStatus(book.getBookStatus())
+                        .quantity(book.getQuantity())
+                        .bookLikeId(book.getBookLikeId())
+                        .isLiked(book.isLiked())
+                        .contributorRoleList(book.getContributorRoleList())
+                        .build()
+                );
+
+        return responses;
+    }
+}

--- a/src/main/java/com/simsimbookstore/apiserver/books/book/service/BookManagementService.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/book/service/BookManagementService.java
@@ -1,6 +1,7 @@
 package com.simsimbookstore.apiserver.books.book.service;
 
 
+import com.simsimbookstore.apiserver.books.book.dto.BookGiftResponse;
 import com.simsimbookstore.apiserver.books.book.dto.BookRequestDto;
 import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
 import com.simsimbookstore.apiserver.books.book.dto.BookStatusResponseDto;
@@ -13,6 +14,7 @@ import com.simsimbookstore.apiserver.books.bookcategory.entity.BookCategory;
 import com.simsimbookstore.apiserver.books.bookcategory.repository.BookCategoryRepository;
 import com.simsimbookstore.apiserver.books.bookcontributor.entity.BookContributor;
 import com.simsimbookstore.apiserver.books.bookcontributor.repository.BookContributorRepository;
+import com.simsimbookstore.apiserver.books.bookimage.repoitory.BookImageRepoisotry;
 import com.simsimbookstore.apiserver.books.booktag.entity.BookTag;
 import com.simsimbookstore.apiserver.books.booktag.repositry.BookTagRepository;
 import com.simsimbookstore.apiserver.books.category.entity.Category;
@@ -21,7 +23,9 @@ import com.simsimbookstore.apiserver.books.contributor.entity.Contributor;
 import com.simsimbookstore.apiserver.books.contributor.repository.ContributorRepositroy;
 import com.simsimbookstore.apiserver.books.tag.domain.Tag;
 import com.simsimbookstore.apiserver.books.tag.repository.TagRepository;
+import com.simsimbookstore.apiserver.exception.BadRequestException;
 import com.simsimbookstore.apiserver.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BookManagementService {
 
@@ -39,27 +44,28 @@ public class BookManagementService {
     private final TagRepository tagRepository;
     private final ContributorRepositroy contributorRepositroy;
     private final BookContributorRepository bookContributorRepository;
+    private final BookImageRepoisotry bookImageRepoisotry;
 
-    public BookManagementService(BookCategoryRepository bookCategoryRepository, BookRepository bookRepository, CategoryRepository categoryRepository
-            , BookTagRepository bookTagRepository, TagRepository tagRepository, ContributorRepositroy contributorRepositroy
-            , BookContributorRepository bookContributorRepository) {
-        this.bookCategoryRepository = bookCategoryRepository;
-        this.bookRepository = bookRepository;
-        this.categoryRepository = categoryRepository;
-        this.bookTagRepository = bookTagRepository;
-        this.tagRepository = tagRepository;
-        this.contributorRepositroy = contributorRepositroy;
-        this.bookContributorRepository = bookContributorRepository;
-    }
 
+    /**
+     * 도서등록
+     *
+     * @param bookRequestDto
+     * @return
+     */
     @Transactional
     public BookResponseDto registerBook(BookRequestDto bookRequestDto) {
         //요청dto를 엔티티로 변경
         Book book = BookMapper.toBook(bookRequestDto);
 
+        // book이 null인지 확인
+        if (book == null) {
+            throw new BadRequestException("Book 객체 생성에 실패했습니다.");
+        }
+
         Book saveBook = bookRepository.save(book);
 
-        //도서 카테고리 연관관계 매핑
+        //도서 카테고리 연관관계 매핑(가장 하위 카테고리만 가져옴)
         List<Long> lowestCategoryId = bookRepository.getLowestCategoryId(bookRequestDto.getCategoryIdList());
         this.saveBookCategory(lowestCategoryId, book);
 
@@ -69,9 +75,66 @@ public class BookManagementService {
         //도서기여자 연관관계 매핑
         this.saveBookContributor(book, bookRequestDto.getContributoridList());
 
+        //this.saveBookImages(book, thumbnail, details);
+
         return BookMapper.toResponseDto(saveBook);
     }
 
+    /**
+     * 도서수정(도서의 상태는 변경x)
+     *
+     * @param bookId
+     * @param requestDto
+     * @return
+     */
+    @Transactional
+    public BookResponseDto updateBook(Long bookId, BookRequestDto requestDto) {
+        Optional<Book> optionalBook = bookRepository.findById(bookId);
+
+        if (optionalBook.isPresent()) {
+            Book book = optionalBook.get();
+
+            Optional.ofNullable(requestDto.getTitle()).ifPresent(book::setTitle);
+            Optional.ofNullable(requestDto.getDescription()).ifPresent(book::setDescription);
+            Optional.ofNullable(requestDto.getBookIndex()).ifPresent(book::setBookIndex);
+            Optional.ofNullable(requestDto.getPublisher()).ifPresent(book::setPublisher);
+            Optional.ofNullable(requestDto.getIsbn()).ifPresent(book::setIsbn);
+            Optional.of(requestDto.getQuantity()).ifPresent(book::setQuantity);
+            Optional.of(requestDto.getPrice()).ifPresent(book::setPrice);
+            Optional.of(requestDto.getSaleprice()).ifPresent(book::setSaleprice);
+            Optional.ofNullable(requestDto.getPublicationDate()).ifPresent(book::setPublicationDate);
+            Optional.of(requestDto.getPages()).ifPresent(book::setPages);
+
+            if (!requestDto.getContributoridList().isEmpty()) {
+                Optional.of(requestDto.getContributoridList()).ifPresent(contributoridList -> {
+                    bookContributorRepository.deleteByBookId(bookId);
+                    this.saveBookContributor(book, contributoridList);
+                });
+            }
+
+            if (!requestDto.getCategoryIdList().isEmpty()) {
+                Optional.of(requestDto.getCategoryIdList()).ifPresent(categoryIdList -> {
+                    bookCategoryRepository.deleteByBookId(bookId);
+                    List<Long> lowestCategoryId = bookRepository.getLowestCategoryId(categoryIdList);
+                    this.saveBookCategory(lowestCategoryId, book);
+                });
+            }
+
+            if (!requestDto.getTagIdList().isEmpty()) {
+                Optional.of(requestDto.getTagIdList()).ifPresent(tagIdList -> {
+                    bookTagRepository.deleteByBookId(bookId);
+                    this.saveBookTag(book, tagIdList);
+                });
+            }
+
+            return BookMapper.toResponseDto(book);
+
+
+        } else {
+            throw new NotFoundException("도서 정보가 없습니다");
+        }
+
+    }
 
     /**
      * 책 등록 시 카테고리 연관관계를 설정하는 메서드 입니다.
@@ -81,6 +144,13 @@ public class BookManagementService {
      */
     @Transactional
     public void saveBookCategory(List<Long> categoryIdList, Book book) {
+
+        if (book == null) {
+            throw new BadRequestException("Book 객체가 null입니다.");
+        }
+        if (categoryIdList == null || categoryIdList.isEmpty()) {
+            return;
+        }
         for (Long categoryId : categoryIdList) {
             Category category = categoryRepository.findById(categoryId)
                     .orElseThrow(() -> new NotFoundException("카테고리가 존재하지 않습니다."));
@@ -101,20 +171,22 @@ public class BookManagementService {
      */
     @Transactional
     public void saveBookTag(Book book, List<Long> tagIdList) {
+        // tagIdList가 null이거나 비어 있으면 작업하지 않습니다.
+        if (tagIdList == null || tagIdList.isEmpty()) {
+            return;
+        }
 
-        // 태그가 없으면 설정하지 않습니다.
-        if (!tagIdList.isEmpty()) {
-            for (Long tagId : tagIdList) {
-                Tag findTag =
-                        tagRepository.findById(tagId).orElseThrow(() -> new NotFoundException("태그 정보가 없습니다."));
-                BookTag bookTag = BookTag.builder()
-                        .book(book)
-                        .tag(findTag)
-                        .build();
-                bookTagRepository.save(bookTag);
-            }
+        for (Long tagId : tagIdList) {
+            Tag tag = tagRepository.findById(tagId).orElseThrow(
+                    () -> new NotFoundException("태그 정보가 없습니다."));
+            BookTag bookTag = BookTag.builder()
+                    .book(book)
+                    .tag(tag)
+                    .build();
+            bookTagRepository.save(bookTag);
         }
     }
+
 
     /**
      * 책 등록 시 기여자와 역할에 대한 설정을 하는 메서드 입니다.
@@ -124,9 +196,12 @@ public class BookManagementService {
      */
     @Transactional
     public void saveBookContributor(Book book, List<Long> contributorIdList) {
-        for (int i = 0; i < contributorIdList.size(); i++) {
 
-            Long contributorId = contributorIdList.get(i);
+        // contributorIdList가 null이거나 비어 있으면 작업하지 않습니다.
+        if (contributorIdList == null || contributorIdList.isEmpty()) {
+            return;
+        }
+        for (Long contributorId : contributorIdList) {
 
             Contributor contributor = contributorRepositroy.findById(contributorId)
                     .orElseThrow(() -> new NotFoundException("기여자 정보가 없습니다."));
@@ -141,7 +216,7 @@ public class BookManagementService {
     }
 
     /**
-     * 도서의 상테를 변경하는 메서드
+     * 도서의 상태만  변경하는 메서드
      *
      * @param bookId
      * @param bookRequestDto
@@ -160,13 +235,29 @@ public class BookManagementService {
                     .bookStatus(book.getBookStatus())
                     .build();
         } else {
-            throw new NotFoundException("책 정보가없습니다");
+            throw new NotFoundException("도서 정보가없습니다");
+        }
+    }
+
+    @Transactional
+    public BookGiftResponse modifyBookGift(Long bookId,BookRequestDto bookRequestDto){
+        Optional<Book> optionalBook = bookRepository.findById(bookId);
+
+        if(optionalBook.isPresent()){
+            Book book = optionalBook.get();
+            book.setGiftPackaging(bookRequestDto.isGiftPackaging());
+
+            return BookGiftResponse.builder()
+                    .giftPackaging(book.isGiftPackaging())
+                    .build();
+        }else {
+            throw new NotFoundException("도서 정보가 없습니다");
         }
     }
 
 
     /**
-     * 도서의 수량을 추가하는 메서드
+     * 도서의 수량을 변경
      *
      * @param bookId
      * @param quantity
@@ -184,7 +275,7 @@ public class BookManagementService {
 
                 if (resultQuantity < 0) {
                     throw new BookOutOfStockException("도서의 수량은 음수가 될 수 없습니다");
-                } else if (resultQuantity == 0) {
+                } else if (resultQuantity == 0) { //재고가 0 이면 매진으로 도서 상태 변경
                     book.setBookStatus(BookStatus.SOLDOUT);
                 }
 
@@ -197,5 +288,6 @@ public class BookManagementService {
             throw new NotFoundException("책 정보가 없습니다");
         }
     }
+
 
 }

--- a/src/main/java/com/simsimbookstore/apiserver/books/bookcategory/repository/BookCategoryRepository.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/bookcategory/repository/BookCategoryRepository.java
@@ -2,6 +2,11 @@ package com.simsimbookstore.apiserver.books.bookcategory.repository;
 
 import com.simsimbookstore.apiserver.books.bookcategory.entity.BookCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface BookCategoryRepository extends JpaRepository<BookCategory,Long> {
+public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
+    @Modifying
+    @Query("DELETE FROM BookCategory bc WHERE bc.book.bookId = :bookId")
+    void deleteByBookId(Long bookId);
 }

--- a/src/main/java/com/simsimbookstore/apiserver/books/bookcontributor/repository/BookContributorRepository.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/bookcontributor/repository/BookContributorRepository.java
@@ -2,6 +2,12 @@ package com.simsimbookstore.apiserver.books.bookcontributor.repository;
 
 import com.simsimbookstore.apiserver.books.bookcontributor.entity.BookContributor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface BookContributorRepository extends JpaRepository<BookContributor,Long> {
+public interface BookContributorRepository extends JpaRepository<BookContributor, Long> {
+
+    @Modifying
+    @Query("DELETE FROM BookContributor bc WHERE bc.book.bookId = :bookId")
+    void deleteByBookId(Long bookId);
 }

--- a/src/main/java/com/simsimbookstore/apiserver/books/bookimage/entity/BookImagePath.java
+++ b/src/main/java/com/simsimbookstore/apiserver/books/bookimage/entity/BookImagePath.java
@@ -28,10 +28,12 @@ public class BookImagePath {
     @Column(name = "image_path", nullable = false)
     private String imagePath;
 
+    @Enumerated(EnumType.STRING)
+    private ImageType imageType;
 
-    //false면 썸내일(커버) 이미지 true면 상세내용에 있는 이미지
-    @Column(name = "thumbnail", nullable = false)
-    private boolean thumbnail = false;
+    public enum ImageType{
+         THUMBNAIL, DETAIL;
 
+    }
 
 }

--- a/src/test/java/com/simsimbookstore/apiserver/books/book/service/BookManagementServiceTest.java
+++ b/src/test/java/com/simsimbookstore/apiserver/books/book/service/BookManagementServiceTest.java
@@ -1,0 +1,284 @@
+package com.simsimbookstore.apiserver.books.book.service;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.simsimbookstore.apiserver.books.book.dto.BookRequestDto;
+import com.simsimbookstore.apiserver.books.book.dto.BookResponseDto;
+import com.simsimbookstore.apiserver.books.book.dto.BookStatusResponseDto;
+import com.simsimbookstore.apiserver.books.book.entity.Book;
+import com.simsimbookstore.apiserver.books.book.entity.BookStatus;
+import com.simsimbookstore.apiserver.books.book.exception.BookOutOfStockException;
+import com.simsimbookstore.apiserver.books.book.mapper.BookMapper;
+import com.simsimbookstore.apiserver.books.book.repository.BookRepository;
+import com.simsimbookstore.apiserver.books.bookcategory.entity.BookCategory;
+import com.simsimbookstore.apiserver.books.bookcategory.repository.BookCategoryRepository;
+import com.simsimbookstore.apiserver.books.bookcontributor.entity.BookContributor;
+import com.simsimbookstore.apiserver.books.bookcontributor.repository.BookContributorRepository;
+import com.simsimbookstore.apiserver.books.booktag.entity.BookTag;
+import com.simsimbookstore.apiserver.books.booktag.repositry.BookTagRepository;
+import com.simsimbookstore.apiserver.books.category.entity.Category;
+import com.simsimbookstore.apiserver.books.category.repository.CategoryRepository;
+import com.simsimbookstore.apiserver.books.contributor.entity.Contributor;
+import com.simsimbookstore.apiserver.books.contributor.repository.ContributorRepositroy;
+import com.simsimbookstore.apiserver.books.tag.domain.Tag;
+import com.simsimbookstore.apiserver.books.tag.repository.TagRepository;
+import com.simsimbookstore.apiserver.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class BookManagementServiceTest {
+
+    @InjectMocks
+    private BookManagementService bookManagementService;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private BookCategoryRepository bookCategoryRepository;
+
+    @Mock
+    private BookTagRepository bookTagRepository;
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private ContributorRepositroy contributorRepositroy;
+
+    @Mock
+    private BookContributorRepository bookContributorRepository;
+
+    @Test
+    void testRegisterBook() {
+        // Arrange
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .title("Test Book")
+                .description("Test Description")
+                .bookIndex("Index")
+                .publisher("Test Publisher")
+                .isbn("1234567890123")
+                .quantity(10)
+                .price(BigDecimal.valueOf(100))
+                .saleprice(BigDecimal.valueOf(80))
+                .publicationDate(LocalDate.now())
+                .pages(200)
+                .bookStatus(BookStatus.ONSALE)
+                .categoryIdList(List.of(1L))
+                .tagIdList(List.of(2L))
+                .contributoridList(List.of(3L))
+                .build();
+
+        Book mockBook = mock(Book.class);
+        when(bookRepository.save(any(Book.class))).thenReturn(mockBook);
+        when(bookRepository.getLowestCategoryId(anyList())).thenReturn(List.of(1L));
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(mock(Category.class)));
+        when(tagRepository.findById(2L)).thenReturn(Optional.of(mock(Tag.class)));
+        when(contributorRepositroy.findById(3L)).thenReturn(Optional.of(mock(Contributor.class)));
+
+        // Act
+        BookResponseDto responseDto = bookManagementService.registerBook(requestDto);
+
+        // Assert
+        assertNotNull(responseDto);
+        verify(bookRepository).save(any(Book.class));
+        verify(bookCategoryRepository).save(any(BookCategory.class));
+        verify(bookTagRepository).save(any(BookTag.class));
+        verify(bookContributorRepository).save(any(BookContributor.class));
+    }
+
+    @Test
+    void testRegisterBookCategoryNotFound() {
+        // Arrange
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .title("Test Book")
+                .description("Test Description")
+                .categoryIdList(List.of(1L)) // 존재하지 않는 카테고리 ID
+                .build();
+
+        when(bookRepository.getLowestCategoryId(anyList())).thenReturn(List.of(1L));
+        when(categoryRepository.findById(1L)).thenReturn(Optional.empty()); // 카테고리 없음
+
+        // Act & Assert
+        assertThrows(NotFoundException.class, () -> bookManagementService.registerBook(requestDto));
+
+        verify(bookRepository, times(1)).save(any(Book.class));
+        verify(categoryRepository, times(1)).findById(1L);
+    }
+
+
+    @Test
+    void testRegisterBookTagNotFound() {
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .tagIdList(List.of(999L))
+                .build();
+
+        when(tagRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> bookManagementService.registerBook(requestDto));
+
+        verify(tagRepository).findById(999L);
+    }
+
+    @Test
+    void testRegisterBookContributorNotFound() {
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .contributoridList(List.of(999L))
+                .build();
+
+        when(contributorRepositroy.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> bookManagementService.registerBook(requestDto));
+
+        verify(contributorRepositroy).findById(999L);
+    }
+
+    @Test
+    void testUpdateBookWithoutConstructor() throws Exception {
+        Long bookId = 1L;
+
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .title("Updated Title")
+                .description("Updated Description")
+                .bookIndex("Updated Index")
+                .publisher("Updated Publisher")
+                .isbn("1234567890123")
+                .quantity(20)
+                .price(BigDecimal.valueOf(200))
+                .saleprice(BigDecimal.valueOf(180))
+                .publicationDate(LocalDate.now())
+                .pages(300)
+                .categoryIdList(List.of(2L))
+                .tagIdList(List.of(3L))
+                .contributoridList(List.of(4L))
+                .build();
+
+        // Book 생성
+        Constructor<Book> bookConstructor = Book.class.getDeclaredConstructor();
+        bookConstructor.setAccessible(true);
+        Book existingBook = bookConstructor.newInstance();
+        Field titleField = Book.class.getDeclaredField("title");
+        titleField.setAccessible(true);
+        titleField.set(existingBook, "Old Title");
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(existingBook));
+        when(bookRepository.getLowestCategoryId(anyList())).thenReturn(List.of(2L));
+
+        // Category 생성
+        Constructor<Category> categoryConstructor = Category.class.getDeclaredConstructor();
+        categoryConstructor.setAccessible(true);
+        Category category = categoryConstructor.newInstance();
+        when(categoryRepository.findById(2L)).thenReturn(Optional.of(category));
+
+        // Contributor 생성
+        Constructor<Contributor> contributorConstructor = Contributor.class.getDeclaredConstructor();
+        contributorConstructor.setAccessible(true);
+        Contributor contributor = contributorConstructor.newInstance();
+        when(contributorRepositroy.findById(4L)).thenReturn(Optional.of(contributor));
+
+        // Tag 설정
+        Constructor<Tag> tagConstructor = Tag.class.getDeclaredConstructor();
+        tagConstructor.setAccessible(true);
+        Tag tag = tagConstructor.newInstance();
+        when(tagRepository.findById(3L)).thenReturn(Optional.of(tag));
+
+        BookResponseDto responseDto = bookManagementService.updateBook(bookId, requestDto);
+
+        assertNotNull(responseDto);
+        assertEquals("Updated Title", existingBook.getTitle());
+        assertEquals("Updated Description", existingBook.getDescription());
+        assertEquals("Updated Index", existingBook.getBookIndex());
+        assertEquals("Updated Publisher", existingBook.getPublisher());
+        assertEquals("1234567890123", existingBook.getIsbn());
+        assertEquals(20, existingBook.getQuantity());
+        assertEquals(BigDecimal.valueOf(200), existingBook.getPrice());
+        assertEquals(BigDecimal.valueOf(180), existingBook.getSaleprice());
+        assertEquals(LocalDate.now(), existingBook.getPublicationDate());
+        assertEquals(300, existingBook.getPages());
+
+        verify(bookRepository).findById(bookId);
+        verify(bookCategoryRepository).deleteByBookId(bookId);
+        verify(bookContributorRepository).deleteByBookId(bookId);
+        verify(bookTagRepository).deleteByBookId(bookId);
+        verify(bookCategoryRepository).save(any());
+        verify(bookTagRepository).save(any());
+        verify(bookContributorRepository).save(any());
+    }
+
+    @Test
+    void testUpdateBookNotFound() {
+        Long bookId = 1L;
+        BookRequestDto requestDto = BookRequestDto.builder().build();
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> bookManagementService.updateBook(bookId, requestDto));
+
+        verify(bookRepository).findById(bookId);
+        verifyNoInteractions(bookCategoryRepository);
+        verifyNoInteractions(bookTagRepository);
+        verifyNoInteractions(bookContributorRepository);
+    }
+
+    @Test
+    void testModifyBookStatusNotFound() {
+        Long bookId = 1L;
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .bookStatus(BookStatus.SOLDOUT)
+                .build();
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> bookManagementService.modifyBookStatus(bookId, requestDto));
+
+        verify(bookRepository).findById(bookId);
+    }
+
+    @Test
+    void testModifyQuantitySOLDOUT() {
+        Long bookId = 1L;
+        int quantity = -10;
+
+        Book book = Book.builder()
+                .quantity(10)
+                .bookStatus(BookStatus.ONSALE)
+                .build();
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+
+        int updatedQuantity = bookManagementService.modifyQuantity(bookId, quantity);
+
+        assertEquals(0, updatedQuantity);
+        assertEquals(BookStatus.SOLDOUT, book.getBookStatus());
+        verify(bookRepository).save(book);
+    }
+
+    @Test
+    void testModifyQuantityNotFound() {
+        Long bookId = 1L;
+        int quantity = 5;
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> bookManagementService.modifyQuantity(bookId, quantity));
+
+        verify(bookRepository).findById(bookId);
+    }
+}


### PR DESCRIPTION
도서 메니지먼트 서비스에서 관리자가 사용할수있는 로직 구현 및 테스트 구현

도서이미지경로 엔티티 수정

저장된 도서 출간일 기준 오름차순으로 불러오는(페이징처리해서) api 구현(완벽하지않음)
->승욱이형이 프론트에서 테스트한다고해서 일단 대충 구현 추후에 수정

api -> http://localhost:8020/api/shop/books?page=0&size=5

남은건 도서 조회하는 로직(quesydsl) 일요일까지 구현예정...